### PR TITLE
building plugin 3DMASC on macOS

### DIFF
--- a/q3DMASCClassifier.cpp
+++ b/q3DMASCClassifier.cpp
@@ -46,6 +46,10 @@
 #include <omp.h>
 #endif
 
+#if defined(__APPLE__)
+#include <unistd.h>
+#endif
+
 using namespace masc;
 
 Classifier::Classifier()


### PR DESCRIPTION
Needed to build on macOS: usleep is provided in unistd.h
With that, the plugin 3DMASC is correctlly built for CloudCompare on macOS.

Paul