### PR TITLE
building plugin 3DMASC on macOS, without OpenMP

### DIFF
--- a/q3DMASCTools.cpp
+++ b/q3DMASCTools.cpp
@@ -1387,7 +1387,11 @@ bool Tools::PrepareFeatures(const CorePoints& corePoints, Feature::Set& features
 				{
 					cancelled = true;
 					success = false;
+#if defined(_OPENMP)
 					errorStr = "Feature computation failed for point " + QString::number(i) + " (using OpenMP with " + QString::number(omp_get_num_threads()) +  " threads)";
+#else
+					errorStr = "Feature computation failed for point " + QString::number(i);
+#endif
 					ccLog::Error(localErrorStr);
 				}
 
@@ -1399,7 +1403,11 @@ bool Tools::PrepareFeatures(const CorePoints& corePoints, Feature::Set& features
 						if (cancelled)
 						{
 							//process cancelled by the user
+#if defined(_OPENMP)
 							errorStr = "Process cancelled at point " + QString::number(i) + " (using OpenMP with " + QString::number(omp_get_num_threads()) +  " threads)";
+#else
+					        errorStr = "Process cancelled at point " + QString::number(i);
+#endif
 							ccLog::Warning(errorStr);
 							success = false;
 						}


### PR DESCRIPTION
I think this patch is required  to build the plugin on macOS, without OpenMP 
Paul