### PR TITLE
cmake: update minimum version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 
 option( PLUGIN_STANDARD_3DMASC "Check to install q3DMASC plugin" OFF )
 


### PR DESCRIPTION
harmless and remove a warning with recent cmake version.