### PR TITLE
Compilation: missing override and switch statement warnings

### DIFF
--- a/ContextBasedFeature.cpp
+++ b/ContextBasedFeature.cpp
@@ -158,7 +158,7 @@ bool ContextBasedFeature::prepare(	const CorePoints& corePoints,
 				errorMessage = "Not enough memory";
 				return false;
 			}
-			
+
 			for (unsigned i = 0; i < classifSF->size(); ++i)
 			{
 				if (classifSF->getValue(i) == fClass)
@@ -223,6 +223,10 @@ bool ContextBasedFeature::prepare(	const CorePoints& corePoints,
 						break;
 					case DH:
 						s = static_cast<ScalarType>(sqrt(pow(P->x - sumQ.x / kNN, 2.0) + pow(P->y - sumQ.y / kNN, 2.0)));
+						break;
+					default:
+						assert(false);
+						s = CCCoreLib::NAN_VALUE;
 						break;
 					}
 				}

--- a/ContextBasedFeature.cpp
+++ b/ContextBasedFeature.cpp
@@ -123,14 +123,14 @@ bool ContextBasedFeature::prepare(	const CorePoints& corePoints,
 
 	//and the scalar field
 	assert(!sf);
-	sf1WasAlreadyExisting = CheckSFExistence(corePoints.cloud, qPrintable(resultSFName));
-	sf = PrepareSF(corePoints.cloud, qPrintable(resultSFName), generatedScalarFields, SFCollector::CAN_REMOVE);
+	sf1WasAlreadyExisting = CheckSFExistence(corePoints.cloud, resultSFName);
+	sf = PrepareSF(corePoints.cloud, resultSFName, generatedScalarFields, SFCollector::CAN_REMOVE);
 	if (!sf)
 	{
 		errorMessage = QString("[ContextBasedFeature::prepare] Failed to prepare scalar %1 @ scale %2").arg(resultSFName).arg(scale);
 		return false;
 	}
-	source.name = sf->getName();
+	source.name = QString::fromStdString(sf->getName());
 
 	// NOT NECESSARY IF THE VALUE IS ALREADY COMPUTED
 	if (!scaled() && !sf1WasAlreadyExisting) //with 'kNN' neighbors, we can compute the values right away

--- a/FeaturesInterface.cpp
+++ b/FeaturesInterface.cpp
@@ -25,21 +25,24 @@
 
 using namespace masc;
 
-bool Feature::CheckSFExistence(ccPointCloud* cloud, const char* resultSFName)
+bool Feature::CheckSFExistence(ccPointCloud* cloud, const QString& resultSFName)
 {
-	if (!cloud || !resultSFName)
+	if (!cloud || resultSFName.isEmpty())
 	{
 		assert(false);
 		return false;
 	}
 
-	int sfIdx = cloud->getScalarFieldIndexByName(resultSFName);
+	int sfIdx = cloud->getScalarFieldIndexByName(resultSFName.toStdString());
 	return (sfIdx >= 0);
 }
 
-CCCoreLib::ScalarField* Feature::PrepareSF(ccPointCloud* cloud, const char* resultSFName, SFCollector* generatedScalarFields/*=nullptr*/, SFCollector::Behavior behavior/*=SFCollector::CAN_REMOVE*/)
+CCCoreLib::ScalarField* Feature::PrepareSF(	ccPointCloud* cloud,
+											const QString& resultSFName,
+											SFCollector* generatedScalarFields/*=nullptr*/,
+											SFCollector::Behavior behavior/*=SFCollector::CAN_REMOVE*/ )
 {
-	if (!cloud || !resultSFName)
+	if (!cloud || resultSFName.isEmpty())
 	{
 		//invalid input parameters
 		assert(false);
@@ -47,7 +50,7 @@ CCCoreLib::ScalarField* Feature::PrepareSF(ccPointCloud* cloud, const char* resu
 	}
 
 	CCCoreLib::ScalarField* resultSF = nullptr;
-	int sfIdx = cloud->getScalarFieldIndexByName(resultSFName);
+	int sfIdx = cloud->getScalarFieldIndexByName(resultSFName.toStdString());
 	if (sfIdx >= 0)
 	{
 		// ccLog::Warning("Existing SF: " + QString(resultSFName) + ", do not store in generatedScalarFields");
@@ -56,7 +59,7 @@ CCCoreLib::ScalarField* Feature::PrepareSF(ccPointCloud* cloud, const char* resu
 	else
 	{
 		// ccLog::Warning("SF does not exist, create it: " + QString(resultSFName)  + ", SFCollector::Behavior " + QString::number(behavior));
-		ccScalarField* newSF = new ccScalarField(resultSFName);
+		ccScalarField* newSF = new ccScalarField(resultSFName.toStdString());
 		if (!newSF->resizeSafe(cloud->size()))
 		{
 			ccLog::Warning("Not enough memory");

--- a/FeaturesInterface.h
+++ b/FeaturesInterface.h
@@ -215,10 +215,10 @@ namespace masc
 	public: //helpers
 
 		//! Creates (or resets) a scalar field with the given name on the input core points cloud
-		static bool CheckSFExistence(ccPointCloud* cloud, const char* resultSFName);
+		static bool CheckSFExistence(ccPointCloud* cloud, const QString& resultSFName);
 
 		//! Creates (or resets) a scalar field with the given name on the input core points cloud
-		static CCCoreLib::ScalarField* PrepareSF(ccPointCloud* cloud, const char* resultSFName, SFCollector* generatedScalarFields/*= nullptr*/, SFCollector::Behavior behavior);
+		static CCCoreLib::ScalarField* PrepareSF(ccPointCloud* cloud, const QString& resultSFName, SFCollector* generatedScalarFields/*= nullptr*/, SFCollector::Behavior behavior);
 
 		//! Performs a mathematical operation between two scalars
 		static ScalarType PerformMathOp(double s1, double s2, Operation op);

--- a/NeighborhoodFeature.cpp
+++ b/NeighborhoodFeature.cpp
@@ -89,23 +89,23 @@ bool NeighborhoodFeature::prepare(	const CorePoints& corePoints,
 
 	//and the scalar field
 	assert(!sf1);
-	sf1WasAlreadyExisting = CheckSFExistence(corePoints.cloud, qPrintable(resultSFName));
+	sf1WasAlreadyExisting = CheckSFExistence(corePoints.cloud, resultSFName);
 	if (sf1WasAlreadyExisting)
 	{
-		sf1 = PrepareSF(corePoints.cloud, qPrintable(resultSFName), generatedScalarFields, SFCollector::ALWAYS_KEEP);
+		sf1 = PrepareSF(corePoints.cloud, resultSFName, generatedScalarFields, SFCollector::ALWAYS_KEEP);
 		if (generatedScalarFields->scalarFields.contains(sf1)) // i.e. the SF is existing but was not present at the startup of the plugin
 			generatedScalarFields->setBehavior(sf1, SFCollector::CAN_REMOVE);
 	}
 	else
 	{
-		sf1 = PrepareSF(corePoints.cloud, qPrintable(resultSFName), generatedScalarFields, SFCollector::CAN_REMOVE);
+		sf1 = PrepareSF(corePoints.cloud, resultSFName, generatedScalarFields, SFCollector::CAN_REMOVE);
 	}
 	if (!sf1)
 	{
 		error = QString("Failed to prepare scalar %1 @ scale %2").arg(resultSFName).arg(scale);
 		return false;
 	}
-	source.name = sf1->getName();
+	source.name = QString::fromStdString(sf1->getName());
 
 	// sf2 is not needed if sf1 was already existing!
 	if (cloud2 && op != Feature::NO_OPERATION && !sf1WasAlreadyExisting)
@@ -114,8 +114,8 @@ bool NeighborhoodFeature::prepare(	const CorePoints& corePoints,
 
 		assert(!sf2);
 
-		sf2WasAlreadyExisting = CheckSFExistence(corePoints.cloud, qPrintable(resultSFName2));		
-		sf2 = PrepareSF(corePoints.cloud, qPrintable(resultSFName2), generatedScalarFields, sf2WasAlreadyExisting ? SFCollector::ALWAYS_KEEP : SFCollector::ALWAYS_REMOVE);
+		sf2WasAlreadyExisting = CheckSFExistence(corePoints.cloud, resultSFName2);		
+		sf2 = PrepareSF(corePoints.cloud, resultSFName2, generatedScalarFields, sf2WasAlreadyExisting ? SFCollector::ALWAYS_KEEP : SFCollector::ALWAYS_REMOVE);
 
 		if (!sf2)
 		{

--- a/Parameters.h
+++ b/Parameters.h
@@ -24,7 +24,7 @@ namespace masc
 	{
 		int maxDepth = 25;			//To be left as a parameter of the training plugin (default 25)
 		int minSampleCount = 1;		//To be left as a parameter of the training plugin (default 1)
-		//int maxCategories = 0;		//Normally not important as there’s no categorical variable
+		//int maxCategories = 0;	//Normally not important as there is no categorical variable
 		int activeVarCount = 0;		//Use 0 as the default parameter (works best)
 		int maxTreeCount = 100;		//Left as a parameter of the training plugin (default: 100)
 	};

--- a/ScalarFieldCollector.cpp
+++ b/ScalarFieldCollector.cpp
@@ -24,7 +24,7 @@
 #include <ScalarField.h>
 
 //system
-#include <assert.h>
+#include <cassert>
 
 void SFCollector::push(ccPointCloud* cloud, CCCoreLib::ScalarField* sf, Behavior behavior)
 {
@@ -52,7 +52,7 @@ void SFCollector::releaseSFs(bool keepByDefault)
 			//keep this SF
 			continue;
 		}
-		
+
 		int sfIdx = desc.cloud->getScalarFieldIndexByName(sf->getName());
 		if (sfIdx >= 0)
 		{

--- a/ScalarFieldCollector.h
+++ b/ScalarFieldCollector.h
@@ -20,9 +20,6 @@
 //Qt
 #include <QMap>
 
-//system
-#include <set>
-
 class ccPointCloud;
 
 namespace CCCoreLib

--- a/ScalarFieldWrappers.h
+++ b/ScalarFieldWrappers.h
@@ -43,10 +43,10 @@ public:
 		: m_sf(sf)
 	{}
 
-	virtual inline double pointValue(unsigned index) const override { return m_sf->getValue(index); }
-	virtual inline bool isValid() const { return m_sf != nullptr; }
-	virtual inline QString getName() const { return QString::fromStdString(m_sf->getName()); }
-	virtual size_t size() const override { return m_sf->size(); }
+	inline double pointValue(unsigned index) const override { return m_sf->getValue(index); }
+	inline bool isValid() const override { return m_sf != nullptr; }
+	inline QString getName() const override { return QString::fromStdString(m_sf->getName()); }
+	size_t size() const override { return m_sf->size(); }
 
 protected:
 	CCCoreLib::ScalarField* m_sf;
@@ -61,16 +61,16 @@ public:
 		, m_name(name)
 	{}
 
-	virtual inline double pointValue(unsigned index) const override
+	inline double pointValue(unsigned index) const override
 	{
 		ScalarType p = m_sfp->getValue(index);
 		ScalarType q = m_sfq->getValue(index);
 		ScalarType ratio = (std::abs(q) > std::numeric_limits<ScalarType>::epsilon() ? p / q : CCCoreLib::NAN_VALUE);
 		return ratio;
 	}
-	virtual inline bool isValid() const { return (m_sfp != nullptr && m_sfq != nullptr); }
-	virtual inline QString getName() const { return m_name; }
-	virtual inline size_t size() const override { return std::min(m_sfp->size(), m_sfq->size()); }
+	inline bool isValid() const override { return (m_sfp != nullptr && m_sfq != nullptr); }
+	inline QString getName() const override { return m_name; }
+	inline size_t size() const override { return std::min(m_sfp->size(), m_sfq->size()); }
 
 protected:
 	CCCoreLib::ScalarField *m_sfp, *m_sfq;
@@ -94,9 +94,9 @@ public:
 		ccNormalVectors::ConvertNormalToDipAndDipDir(N, dip_deg, dipDir_deg);
 		return (m_mode == Dip ? dip_deg : dipDir_deg);
 	}
-	virtual inline bool isValid() const { return m_cloud != nullptr && m_cloud->hasNormals(); }
-	virtual inline QString getName() const { static const char s_names[][14] = { "Norm dip", "Norm dip dir." }; return s_names[m_mode]; }
-	virtual inline size_t size() const override { return m_cloud->size(); }
+	inline bool isValid() const override { return m_cloud != nullptr && m_cloud->hasNormals(); }
+	inline QString getName() const override { static const char s_names[][14] = { "Norm dip", "Norm dip dir." }; return s_names[m_mode]; }
+	inline size_t size() const override { return m_cloud->size(); }
 
 protected:
 	const ccPointCloud* m_cloud;
@@ -107,16 +107,16 @@ class DimScalarFieldWrapper : public IScalarFieldWrapper
 {
 public:
 	enum Dim { DimX = 0, DimY = 1, DimZ = 2 };
-	
+
 	DimScalarFieldWrapper(const ccPointCloud* cloud, Dim dim)
 		: m_cloud(cloud)
 		, m_dim(dim)
 	{}
 
-	virtual inline double pointValue(unsigned index) const override { return m_cloud->getPoint(index)->u[m_dim]; }
-	virtual inline bool isValid() const { return m_cloud != nullptr; }
-	virtual inline QString getName() const { static const char s_names[][5] = { "DimX", "DimY", "DimZ" }; return s_names[m_dim]; }
-	virtual inline size_t size() const override { return m_cloud->size(); }
+	inline double pointValue(unsigned index) const override { return m_cloud->getPoint(index)->u[m_dim]; }
+	inline bool isValid() const override { return m_cloud != nullptr; }
+	inline QString getName() const override { static const char s_names[][5] = { "DimX", "DimY", "DimZ" }; return s_names[m_dim]; }
+	inline size_t size() const override { return m_cloud->size(); }
 
 protected:
 	const ccPointCloud* m_cloud;
@@ -133,10 +133,10 @@ public:
 		, m_band(band)
 	{}
 
-	virtual inline double pointValue(unsigned index) const override { return m_cloud->getPointColor(index).rgba[m_band]; }
-	virtual inline bool isValid() const { return m_cloud != nullptr && m_cloud->hasColors(); }
-	virtual inline QString getName() const { static const char s_names[][6] = { "Red", "Green", "Blue" }; return s_names[m_band]; }
-	virtual inline size_t size() const override { return m_cloud->size(); }
+	inline double pointValue(unsigned index) const override { return m_cloud->getPointColor(index).rgba[m_band]; }
+	inline bool isValid() const override{ return m_cloud != nullptr && m_cloud->hasColors(); }
+	inline QString getName() const override { static const char s_names[][6] = { "Red", "Green", "Blue" }; return s_names[m_band]; }
+	inline size_t size() const override { return m_cloud->size(); }
 
 protected:
 	const ccPointCloud* m_cloud;

--- a/ScalarFieldWrappers.h
+++ b/ScalarFieldWrappers.h
@@ -43,9 +43,9 @@ public:
 		: m_sf(sf)
 	{}
 
-	virtual inline double pointValue(unsigned index) const override { return m_sf->at(index); }
+	virtual inline double pointValue(unsigned index) const override { return m_sf->getValue(index); }
 	virtual inline bool isValid() const { return m_sf != nullptr; }
-	virtual inline QString getName() const { return m_sf->getName(); }
+	virtual inline QString getName() const { return QString::fromStdString(m_sf->getName()); }
 	virtual size_t size() const override { return m_sf->size(); }
 
 protected:

--- a/confusionmatrix.h
+++ b/confusionmatrix.h
@@ -3,7 +3,7 @@
 #include <QWidget>
 #include <set>
 
-#include "CCTypes.h"
+#include <GenericDistribution.h>
 
 #include <ccMainAppInterface.h>
 
@@ -25,13 +25,12 @@ public:
 		F1_SCORE = 2
 	};
 
-	explicit ConfusionMatrix(const std::vector<ScalarType>& actual,
-								const std::vector<ScalarType>& predicted);
+	explicit ConfusionMatrix(const CCCoreLib::GenericDistribution::ScalarContainer& actual, const CCCoreLib::GenericDistribution::ScalarContainer& predicted);
 	~ConfusionMatrix() override;
 
 	void computePrecisionRecallF1Score(cv::Mat& matrix, cv::Mat& precisionRecallF1Score, cv::Mat &vec_TP_FN);
 	float computeOverallAccuracy(cv::Mat& matrix);
-	void compute(const std::vector<ScalarType> &actual, const std::vector<ScalarType> &predicted);
+	void compute(const CCCoreLib::GenericDistribution::ScalarContainer& actual, const CCCoreLib::GenericDistribution::ScalarContainer& predicted);
 	void setSessionRun(QString session, int run);
 	bool save(QString filePath);
 	float getOverallAccuracy();

--- a/q3DMASCClassifier.cpp
+++ b/q3DMASCClassifier.cpp
@@ -70,7 +70,7 @@ static IScalarFieldWrapper::Shared GetSource(const Feature::Source& fs, const cc
 	case Feature::Source::ScalarField:
 	{
 		assert(!fs.name.isEmpty());
-		int sfIdx = cloud->getScalarFieldIndexByName(qPrintable(fs.name));
+		int sfIdx = cloud->getScalarFieldIndexByName(fs.name.toStdString());
 		if (sfIdx >= 0)
 		{
 			source.reset(new ScalarFieldWrapper(cloud->getScalarField(sfIdx)));
@@ -288,7 +288,8 @@ bool Classifier::classify(	const Feature::Source::Set& featureSources,
 	{
 		if (app)
 		{
-			ConfusionMatrix *confusionMatrix = new ConfusionMatrix(*classifSFBackup, *classificationSF);
+			ConfusionMatrix* confusionMatrix = new ConfusionMatrix(CCCoreLib::GenericDistribution::SFAsScalarContainer(*classifSFBackup),
+				CCCoreLib::GenericDistribution::SFAsScalarContainer(*classificationSF));
 		}
 	}
 
@@ -346,12 +347,12 @@ bool Classifier::evaluate(const Feature::Source::Set& featureSources,
 
 	if (!outputSFName.isEmpty())
 	{
-		int outIdx = testCloud->getScalarFieldIndexByName(qPrintable(outputSFName));
+		int outIdx = testCloud->getScalarFieldIndexByName(outputSFName.toStdString());
 		if (outIdx >= 0)
 			testCloud->deleteScalarField(outIdx);
 		else
 			ccLog::Print("add " + outputSFName + " to the TEST cloud");
-		outIdx = testCloud->addScalarField(qPrintable(outputSFName));
+		outIdx = testCloud->addScalarField(outputSFName.toStdString());
 		outSF  = static_cast<ccScalarField*>(testCloud->getScalarField(outIdx));
 	}
 
@@ -481,7 +482,8 @@ bool Classifier::evaluate(const Feature::Source::Set& featureSources,
 		metrics.ratio = static_cast<float>(metrics.goodGuess) / metrics.sampleCount;
 	}
 
-	ConfusionMatrix* confusionMatrix = new ConfusionMatrix(actualClass, predictectedClass);
+	ConfusionMatrix* confusionMatrix = new ConfusionMatrix(CCCoreLib::GenericDistribution::VectorAsScalarContainer(actualClass),
+		CCCoreLib::GenericDistribution::VectorAsScalarContainer(predictectedClass));
 	train3DMASCDialog.addConfusionMatrixAndSaveTraces(confusionMatrix);
 	if (app)
 	{

--- a/q3DMASCTools.cpp
+++ b/q3DMASCTools.cpp
@@ -1013,14 +1013,14 @@ CCCoreLib::ScalarField* Tools::RetrieveSF(const ccPointCloud* cloud, const QStri
 	int sfIdx = -1;
 	if (caseSensitive)
 	{
-		sfIdx = cloud->getScalarFieldIndexByName(qPrintable(sfName));
+		sfIdx = cloud->getScalarFieldIndexByName(sfName.toStdString());
 	}
 	else
 	{
 		QString sfNameUpper = sfName.toUpper();
 		for (unsigned i = 0; i < cloud->getNumberOfScalarFields(); ++i)
 		{
-			if (QString(cloud->getScalarField(i)->getName()).toUpper() == sfNameUpper)
+			if (QString::fromStdString(cloud->getScalarField(i)->getName()).toUpper() == sfNameUpper)
 			{
 				sfIdx = static_cast<int>(i);
 				break;

--- a/q3DMASCTools.cpp
+++ b/q3DMASCTools.cpp
@@ -42,7 +42,7 @@
 #include <QCoreApplication>
 
 //system
-#include <assert.h>
+#include <cassert>
 
 #if defined(_OPENMP)
 #include <omp.h>
@@ -96,7 +96,7 @@ bool Tools::SaveClassifier(	QString filename,
 	{
 		stream << "cloud: " << label << endl;
 	}
-	
+
 	if (!corePointsRole.isEmpty())
 	{
 		stream << "# Core points (classified role)" << endl;
@@ -686,7 +686,7 @@ static bool ReadCorePoints(const QString& command, const Tools::NamedClouds& clo
 
 		} //end of subsampling options
 	}
-	
+
 	return true;
 }
 
@@ -698,7 +698,7 @@ static bool ReadCloud(const QString& command, Tools::NamedClouds& clouds, const 
 		ccLog::Warning("Malformed file: expecting 2 tokens after 'cloud:' on line #" + QString::number(lineNumber));
 		return false;
 	}
-	
+
 	QString pcName = tokens[0].trimmed();
 	QString pcFilename = defaultDir.absoluteFilePath(tokens[1].trimmed());
 	//try to open the cloud
@@ -1027,7 +1027,7 @@ CCCoreLib::ScalarField* Tools::RetrieveSF(const ccPointCloud* cloud, const QStri
 			}
 		}
 	}
-	
+
 	if (sfIdx >= 0)
 	{
 		return cloud->getScalarField(sfIdx);

--- a/qTrain3DMASCDialog.cpp
+++ b/qTrain3DMASCDialog.cpp
@@ -31,8 +31,6 @@
 //System
 #include <assert.h>
 
-#include <iostream>
-
 static const int FeatureImportanceColumn = 1;
 
 Train3DMASCDialog::Train3DMASCDialog(QWidget* parent/*=nullptr*/)


### PR DESCRIPTION
This is a minor cleanup in order to silent some compiler warnings.

- add a bunch of missing override
- handle the missing default case in a switch statement
- use utf-8 encoding in every file
- header cleanup

This PR also push the changes in https://github.com/dgirardeau/q3DMASC/tree/double_sf. appears that the CC 3DMASC submodule is following the double_sf branch instead of the master branch. Should we update the master branch, or should I target my PR against the double_sf branch?"